### PR TITLE
Fix reset time bug

### DIFF
--- a/Assets/Scripts/Player/GameClock.cs
+++ b/Assets/Scripts/Player/GameClock.cs
@@ -45,6 +45,15 @@ public class GameClock : MonoBehaviour
         }
     }
 
+    // Resets the clock back to the initial starting time
+    public void ResetTime()
+    {
+        currentDayIndex = 0; // Monday
+        currentHour = 7;
+        currentMinute = 0;
+        UpdateTimeDisplay();
+    }
+
     void UpdateTimeDisplay()
     {
         string formattedTime = string.Format("{0} {1:00}:{2:00}", daysOfWeek[currentDayIndex], currentHour, currentMinute);

--- a/Assets/Scripts/Player/GameOverManager.cs
+++ b/Assets/Scripts/Player/GameOverManager.cs
@@ -78,9 +78,8 @@ public class GameOverManager : MonoBehaviour
         pizzaManager.RemoveMoney(pizzaManager.GetCurrentMoney()); // $0
         playerMovement.RestoreEnergy(); // 100 energy
 
-        // Reset time
-        for (int i = 0; i < 48; i++) // Reset to Monday 07:00 (full week reset)
-            gameClock.Advance30Minutes();
+        // Reset time completely back to the initial starting day
+        gameClock.ResetTime();
 
         // Respawn player at bed
         player.position = bedSpawnPoint.position + Vector3.up * 1f;


### PR DESCRIPTION
## Summary
- add a `ResetTime` helper in `GameClock`
- use the helper to reset the clock during game over

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f989fd4d4832d8459127a0e6b7aee