### PR TITLE
Add edit mode test for GameClock

### DIFF
--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c8ad99cb9e0148eda20070cfee789ee0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode.meta
+++ b/Assets/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b250c726ef2486dbcae7c63b762f89d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/GameClockTests.cs
+++ b/Assets/Tests/EditMode/GameClockTests.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+public class GameClockTests
+{
+    [Test]
+    public void Advance30MinutesTwice_UpdatesHourAndDay()
+    {
+        var go = new GameObject();
+        var clock = go.AddComponent<GameClock>();
+
+        // Set time to 23:30 on Monday
+        var hourField = typeof(GameClock).GetField("currentHour", BindingFlags.NonPublic | BindingFlags.Instance);
+        var minuteField = typeof(GameClock).GetField("currentMinute", BindingFlags.NonPublic | BindingFlags.Instance);
+        var dayField = typeof(GameClock).GetField("currentDayIndex", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        hourField.SetValue(clock, 23);
+        minuteField.SetValue(clock, 30);
+        dayField.SetValue(clock, 0);
+
+        // Act
+        clock.Advance30Minutes();
+        clock.Advance30Minutes();
+
+        // Assert
+        Assert.AreEqual(0, clock.GetHour(), "Hour should wrap to 0 after midnight.");
+        Assert.AreEqual(30, clock.GetMinute(), "Minute should be 30 after two advances.");
+        Assert.AreEqual(1, (int)dayField.GetValue(clock), "Day should advance by one after crossing midnight.");
+
+        Object.DestroyImmediate(go);
+    }
+}

--- a/Assets/Tests/EditMode/GameClockTests.cs.meta
+++ b/Assets/Tests/EditMode/GameClockTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 32dcba9e158247e689761cbd51addd94


### PR DESCRIPTION
## Summary
- set up a new `Assets/Tests/EditMode` folder with meta files
- implement `GameClockTests` to ensure `Advance30Minutes()` handles day rollover

## Testing
- ❌ `Unity` tests *(failed: `Unity` is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_683f9a000184832d8e7b1f62012d8621