### PR TITLE
Add save system to persist player state

### DIFF
--- a/Assets/Scripts/Player/Bed.cs
+++ b/Assets/Scripts/Player/Bed.cs
@@ -81,6 +81,10 @@ public class Bed : MonoBehaviour
             yield return null;
         }
 
+        SaveSystem system = FindObjectOfType<SaveSystem>();
+        if (system != null)
+            system.SaveGame();
+
         // Re-enable movement and look
         playerMovement.enabled = true;
         if (look != null) look.enabled = true;

--- a/Assets/Scripts/Player/GameClock.cs
+++ b/Assets/Scripts/Player/GameClock.cs
@@ -70,4 +70,17 @@ public class GameClock : MonoBehaviour
         return currentMinute;
     }
 
+    public int GetDay()
+    {
+        return currentDayIndex;
+    }
+
+    public void SetTime(int dayIndex, int hour, int minute)
+    {
+        currentDayIndex = dayIndex;
+        currentHour = hour;
+        currentMinute = minute;
+        UpdateTimeDisplay();
+    }
+
 }

--- a/Assets/Scripts/Player/MainMenu.cs
+++ b/Assets/Scripts/Player/MainMenu.cs
@@ -13,6 +13,9 @@ public class MainMenu : MonoBehaviour
     }
     public void QuitGame()
     {
+        SaveSystem system = FindObjectOfType<SaveSystem>();
+        if (system != null)
+            system.SaveGame();
         Application.Quit();
     }
 

--- a/Assets/Scripts/Player/MainMenuManager.cs
+++ b/Assets/Scripts/Player/MainMenuManager.cs
@@ -34,7 +34,12 @@ public class MainMenuManager : MonoBehaviour
         player.SetActive(false); // Hide player control until game starts
 
         playButton.onClick.AddListener(StartGame);
-        quitButton.onClick.AddListener(() => Application.Quit());
+        quitButton.onClick.AddListener(() => {
+            SaveSystem system = FindObjectOfType<SaveSystem>();
+            if (system != null)
+                system.SaveGame();
+            Application.Quit();
+        });
     }
 
     public void StartGame()

--- a/Assets/Scripts/Player/PizzaManager.cs
+++ b/Assets/Scripts/Player/PizzaManager.cs
@@ -109,6 +109,12 @@ public class PizzaManager : MonoBehaviour
         return money;
     }
 
+    public void SetMoney(float amount)
+    {
+        money = amount;
+        UpdateMoneyUI();
+    }
+
     public void RemoveMoney(float amount)
     {
         money -= amount;

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -136,6 +136,12 @@ public class PlayerMovement : MonoBehaviour
         return energy;
     }
 
+    public void SetEnergy(float value)
+    {
+        energy = value;
+        UpdateEnergyUI();
+    }
+
     void ApplyCrouch()
     {
         controller.height = isCrouching ? crouchingHeight : standingHeight;

--- a/Assets/Scripts/SaveSystem.cs
+++ b/Assets/Scripts/SaveSystem.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using System.Reflection;
+
+public class SaveSystem : MonoBehaviour
+{
+    public PizzaManager pizzaManager;
+    public PlayerMovement playerMovement;
+    public GameClock gameClock;
+
+    private static SaveSystem instance;
+    public static SaveSystem Instance => instance;
+
+    void Awake()
+    {
+        if (instance == null)
+        {
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+            LoadGame();
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    public void SaveGame()
+    {
+        if (pizzaManager != null)
+            PlayerPrefs.SetFloat("Money", pizzaManager.GetCurrentMoney());
+
+        if (playerMovement != null)
+            PlayerPrefs.SetFloat("Energy", playerMovement.GetEnergy());
+
+        if (gameClock != null)
+        {
+            var dayField = typeof(GameClock).GetField("currentDayIndex", BindingFlags.NonPublic | BindingFlags.Instance);
+            var hourField = typeof(GameClock).GetField("currentHour", BindingFlags.NonPublic | BindingFlags.Instance);
+            var minuteField = typeof(GameClock).GetField("currentMinute", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (dayField != null) PlayerPrefs.SetInt("Day", (int)dayField.GetValue(gameClock));
+            if (hourField != null) PlayerPrefs.SetInt("Hour", (int)hourField.GetValue(gameClock));
+            if (minuteField != null) PlayerPrefs.SetInt("Minute", (int)minuteField.GetValue(gameClock));
+        }
+
+        PlayerPrefs.Save();
+    }
+
+    public void LoadGame()
+    {
+        if (pizzaManager != null && PlayerPrefs.HasKey("Money"))
+        {
+            float money = PlayerPrefs.GetFloat("Money");
+            var field = typeof(PizzaManager).GetField("money", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field != null) field.SetValue(pizzaManager, money);
+            pizzaManager.SendMessage("UpdateMoneyUI", SendMessageOptions.DontRequireReceiver);
+        }
+
+        if (playerMovement != null && PlayerPrefs.HasKey("Energy"))
+        {
+            playerMovement.SetEnergy(PlayerPrefs.GetFloat("Energy"));
+        }
+
+        if (gameClock != null && PlayerPrefs.HasKey("Day"))
+        {
+            int day = PlayerPrefs.GetInt("Day");
+            int hour = PlayerPrefs.GetInt("Hour");
+            int minute = PlayerPrefs.GetInt("Minute");
+            gameClock.SetTime(day, hour, minute);
+        }
+    }
+
+    void OnApplicationQuit()
+    {
+        SaveGame();
+    }
+}

--- a/Assets/Scripts/SaveSystem.cs.meta
+++ b/Assets/Scripts/SaveSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cc7d8a3fefcb4f1abb931306a84c7e8b


### PR DESCRIPTION
## Summary
- introduce `SaveSystem` for saving money, energy and time
- allow money, energy, and time to be set via new methods
- save game when player sleeps or quits

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684147dbfdb0832da49328aa6948f289